### PR TITLE
SS-28758: Integrate RdKitJS library for certain server functionalities

### DIFF
--- a/src/script/api.js
+++ b/src/script/api.js
@@ -78,10 +78,6 @@ function api(base, defaultOptions) {
 	return Object.assign(info, {
 		convert: indigoCall('POST', 'indigo/convert'),
 		layout: indigoCall('POST', 'indigo/layout'),
-		clean: indigoCall('POST', 'indigo/clean'),
-		aromatize: indigoCall('POST', 'indigo/aromatize'),
-		dearomatize: indigoCall('POST', 'indigo/dearomatize'),
-		calculateCip: indigoCall('POST', 'indigo/calculate_cip'),
 		automap: indigoCall('POST', 'indigo/automap'),
 		check: indigoCall('POST', 'indigo/check'),
 		calculate: indigoCall('POST', 'indigo/calculate'),

--- a/src/script/ui/action/index.js
+++ b/src/script/ui/action/index.js
@@ -20,6 +20,7 @@ import tools from './tools';
 import atoms from './atoms';
 import zoom from './zoom';
 import server from './server';
+import rdkitjstools from './rdkitjstools';
 import debug from './debug';
 import templates from './templates';
 import { exec } from '../component/cliparea';
@@ -148,6 +149,7 @@ export default {
 		}
 	},
 	...server,
+	...rdkitjstools,
 	...debug,
 	...tools,
 	...atoms,

--- a/src/script/ui/action/rdkitjstools.js
+++ b/src/script/ui/action/rdkitjstools.js
@@ -1,0 +1,38 @@
+import { rdkitJsTransform, rdkitJsCIP } from '../state/rdkitjs';
+
+export default {
+	arom: {
+		title: 'Aromatize',
+		action: {
+			thunk: rdkitJsTransform('aromatize')
+		},
+		className: 'rdkitjs',
+		disabled: () => true
+	},
+	dearom: {
+		title: 'Dearomatize',
+		action: {
+			thunk: rdkitJsTransform('dearomatize')
+		},
+		className: 'rdkitjs',
+		disabled: () => true
+	},
+	clean: {
+		shortcut: 'Mod+Shift+l',
+		title: 'Clean Up',
+		action: {
+			thunk: rdkitJsTransform('clean')
+		},
+		className: 'rdkitjs',
+		disabled: () => true
+	},
+	cip: {
+		shortcut: 'Mod+p',
+		title: 'Calculate CIP',
+		action: {
+			thunk: rdkitJsCIP()
+		},
+		className: 'rdkitjs',
+		disabled: () => true
+	}
+};

--- a/src/script/ui/action/server.js
+++ b/src/script/ui/action/server.js
@@ -25,36 +25,6 @@ export default {
 		},
 		disabled: (editor, server, options) => !options.app.server
 	},
-	clean: {
-		shortcut: 'Mod+Shift+l',
-		title: 'Clean Up',
-		action: {
-			thunk: serverTransform('clean')
-		},
-		disabled: (editor, server, options) => !options.app.server
-	},
-	arom: {
-		title: 'Aromatize',
-		action: {
-			thunk: serverTransform('aromatize')
-		},
-		disabled: (editor, server, options) => !options.app.server
-	},
-	dearom: {
-		title: 'Dearomatize',
-		action: {
-			thunk: serverTransform('dearomatize')
-		},
-		disabled: (editor, server, options) => !options.app.server
-	},
-	cip: {
-		shortcut: 'Mod+p',
-		title: 'Calculate CIP',
-		action: {
-			thunk: serverTransform('calculateCip')
-		},
-		disabled: (editor, server, options) => !options.app.server
-	},
 	check: {
 		title: 'Check Structure',
 		action: { dialog: 'check' },

--- a/src/script/ui/component/actionmenu.jsx
+++ b/src/script/ui/component/actionmenu.jsx
@@ -74,6 +74,7 @@ function ActionButton({ name, action, status = {}, onAction }) { // eslint-disab
 				}
 			}}
 			title={shortcut ? `${action.title} (${shortcut})` : action.title}
+			className={action.className}
 		>
 			<Icon name={name} />{action.title}<kbd>{shortcut}</kbd>
 		</button>

--- a/src/script/ui/state/rdkitjs/index.js
+++ b/src/script/ui/state/rdkitjs/index.js
@@ -63,8 +63,8 @@ export function calculateCip(result) {
 		deleteAllSGroupsWithName(restruct, action, attributes.fieldName);
 		result.CIP_atoms.forEach((a) => {
 			const [index, fieldValue] = a;
-			const atomIdx = keys[index];
-			const atom = restruct.molecule.atoms.get(atomIdx);
+			const atomKey = keys[index];
+			const atom = restruct.molecule.atoms.get(atomKey);
 			attributes.fieldValue = fieldValue;
 			action.mergeWith(fromSgroupAddition(restruct, 'DAT', [atomIdx], attributes, undefined, atom.pp));
 		});

--- a/src/script/ui/state/rdkitjs/index.js
+++ b/src/script/ui/state/rdkitjs/index.js
@@ -1,0 +1,104 @@
+import molfile from '../../../chem/molfile';
+import { load } from '../shared';
+import Action from '../../../editor/shared/action';
+import { fromSgroupAddition, fromSgroupDeletion } from '../../../editor/actions/sgroup';
+import Vec2 from '../../../util/vec2';
+
+/**
+ * Performs transformation on the Molecule present in Ketcher, using utilities
+ * from the RDKit JS library.
+ *
+ * @param method: the RdkitJS transformation method to call
+ * @returns {Function}
+ */
+export function rdkitJsTransform(method) {
+	return (dispatch, getState) => {
+		const state = getState();
+		const struct = state.editor.struct().clone(null, null, false, new Map());
+		const mol = Module.get_mol(molfile.stringify(struct, // eslint-disable-line no-undef
+			{ ignoreErrors: true }));
+		if (!mol.is_valid()) {
+			alert(`The specified input molecule is invalid.`);
+			return;
+		}
+		dispatch(load(doTransformation(method, mol), {
+			rescale: method === 'layout',
+			reactionRelayout: method === 'clean'
+		}));
+	};
+}
+
+
+export function rdkitJsCIP() {
+	return (dispatch, getState) => {
+		const state = getState();
+		const struct = state.editor.struct().clone(null, null, false, new Map());
+		const mol = Module.get_mol(molfile.stringify(struct, // eslint-disable-line no-undef
+			{ ignoreErrors: true }));
+		if (!mol.is_valid()) {
+			alert(`The specified input molecule is invalid.`);
+			return;
+		}
+		const res = JSON.parse(mol.get_stereo_tags());
+		dispatch(calculateCip(res));
+	};
+}
+
+export function calculateCip(result) {
+	return (dispatch, getState) => {
+		const state = getState();
+		const editor = state.editor;
+		const restruct = editor.render.ctab;
+		const atomsIterator = restruct.molecule.atoms.keys();
+		const keys = [...atomsIterator];
+		const attributes = {
+			absolute: false,
+			attached: false,
+			context: 'Atom',
+			fieldName: 'CIP_DESC',
+			fieldValue: '(R)',
+			init: true
+		};
+		const action = new Action();
+		deleteAllSGroupsWithName(restruct, action, attributes.fieldName);
+		result.CIP_atoms.forEach((a) => {
+			const [index, fieldValue] = a;
+			const atomIdx = keys[index];
+			const atom = restruct.molecule.atoms.get(atomIdx);
+			attributes.fieldValue = fieldValue;
+			action.mergeWith(fromSgroupAddition(restruct, 'DAT', [atomIdx], attributes, undefined, atom.pp));
+		});
+		result.CIP_bonds.forEach((b) => {
+			const [atom1Index, atom2Index] = b;
+			const atom1Idx = keys[atom1Index];
+			const atom2Idx = keys[atom2Index];
+			const atom1 = restruct.molecule.atoms.get(atom1Idx);
+			const atom2 = restruct.molecule.atoms.get(atom2Idx);
+			attributes.fieldValue = b[2];
+			const pp = new Vec2((atom1.pp.x + atom2.pp.x) * 0.5,
+				(atom1.pp.y + atom2.pp.y) * 0.5);
+			action.mergeWith(fromSgroupAddition(restruct, 'DAT', [atom1Idx, atom2Idx], attributes, undefined, pp));
+		});
+		editor.update(action);
+	};
+}
+
+function deleteAllSGroupsWithName(restruct, action, fieldName) {
+	restruct.molecule.sgroups.forEach((sg, id) => {
+		if (sg.data.fieldName === fieldName)
+			action.mergeWith(fromSgroupDeletion(restruct, id));
+	});
+}
+
+function doTransformation(method, mol) {
+	switch (method) {
+		case 'aromatize':
+			return mol.get_aromatic_form();
+		case 'dearomatize':
+			return mol.get_kekule_form();
+		case 'clean':
+			return mol.get_new_coords();
+		default:
+			return '';
+	}
+}

--- a/src/template/index.hbs
+++ b/src/template/index.hbs
@@ -11,8 +11,21 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="logo/apple-touch-icon.png">
 
     <link rel="stylesheet" href="{{pkg.name}}.css">
+    <script>
+			var Module = {
+				onRuntimeInitialized: function () {
+					// RDKitJS WebAssembly has successfully completed compilation.
+					// We can enable the RDKit JS-powered tools at this point.
+					var rdKitJsTools = document.getElementsByClassName('rdkitjs');
+					Array.from(rdKitJsTools).forEach((tool) => {
+					  tool.removeAttribute('disabled');
+					});
+				}
+			};
+		</script>
 		<script src="raphael.min.js"></script>
 		<script src="{{pkg.name}}.js"></script>
+		<script src="https://rdkit.org/rdkitjs/beta/RDKit_minimal.js"></script>
 
     {{#if miew}}
         <link rel="stylesheet" href="Miew.min.css">


### PR DESCRIPTION
- Added a simple plug-n-play architecture, for adding new functionalities that utilize methods from the [RDKitJS repo](https://github.com/rdkit/rdkit/tree/master/Code/MinimalLib)
- Migrated 4 of the server side functionalities to utilize the corresponding RDKit JS lib methods: 
(i) Aromatize: `get_aromatic_form`
(ii) Dearomatize: `get_kekule_form`
(iii) 2D Clean: `get_new_coords`
(iv) Calculate CIP : `get_stereo_tags`

- Downloaded the already built JS & Wasm files from [here](https://rdkit.org/temp/demo/)
- Verified that these functionalities work fine, could be tried out at http://ld-desis.dev.bb.schrodinger.com:9145/livedesign/ketcher2/ketcher.html
- Added 'how-to-add' RDkit JS lib functionality steps in the existing document maintained [here](https://docs.google.com/document/d/1mPmgPP26_Mi4swJamIYLBWoqUCJ2bNeiGbwbbVpDmEk/edit)

Primary - @mycrobe 
