### PR TITLE
SS-28771: POC: Integrate Ketcher with LiveDesign [Enumeration + Compounds Pane]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /node_modules
 /*.zip
 /dist
-/indigo
 
 .idea/
 *.pyc

--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -18,7 +18,7 @@ const cp = require('child_process');
 module.exports.version = function (options, cb) {
 	const pkg = options.pkg;
 	if (pkg.rev) return cb();
-	cp.exec('git rev-list ' + pkg.version + '..HEAD --count', function (err, stdout, stderr) {
+	cp.exec('git log --pretty=oneline ' + pkg.version + '..HEAD | wc -l', function (err, stdout, stderr) {
 		if (err && stderr.toString().search('path not in') > 0) {
 			cb(new Error('Could not fetch revision. ' +
 				'Please git tag the package version.'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,7 +124,6 @@ gulp.task('clean', getTask('./gulp/clean', {
 	pkgName: pkg.name
 }));
 
-gulp.task('pre-commit', ['lint', 'check-epam-email', 'check-deps-exact']);
 gulp.task('assets', ['copy', 'help']);
 gulp.task('code', ['style', 'script', 'html']);
 

--- a/src/script/index.js
+++ b/src/script/index.js
@@ -42,11 +42,38 @@ function getMolfile() {
 		{ ignoreErrors: true });
 }
 
+
+function getRepresentationInFormat(format) {
+	const input_mol = molfile.stringify(ketcher.editor.struct(),
+		{ ignoreErrors: true });
+	return new Promise((resolve) => {
+		$.ajax({
+			type: "POST",
+			url: '/plexus/rest-v0/util/calculate/stringMolExport',
+			data: { structure: input_mol, parameters: format }
+		}).done(function updateInputCompound(smiles) {
+			resolve(smiles);
+		});
+	});
+}
+
+function getSvg() {
+	const mol = Module.get_mol(molfile.stringify(ketcher.editor.struct(), // eslint-disable-line no-undef
+		{ ignoreErrors: true }));
+	return mol.get_svg();
+}
+
 function setMolecule(molString) {
 	if (!(typeof molString === 'string'))
 		return;
-	ketcher.ui.load(molString, {
-		rescale: true
+	$.ajax({
+		type: "POST",
+		url: '/plexus/rest-v0/util/calculate/stringMolExport',
+		data: { structure: molString, parameters: 'MOL' }
+	}).done(function updateInputCompound(smiles) {
+		ketcher.ui.load(smiles, {
+			rescale: true
+		});
 	});
 }
 
@@ -103,8 +130,10 @@ const buildInfo = {
 
 const ketcher = module.exports = Object.assign({ // eslint-disable-line no-multi-assign
 	getSmiles,
+	getSvg,
 	saveSmiles,
 	getMolfile,
+	getRepresentationInFormat,
 	setMolecule,
 	addFragment,
 	showMolfile

--- a/src/script/index.js
+++ b/src/script/index.js
@@ -42,30 +42,40 @@ function getMolfile() {
 		{ ignoreErrors: true });
 }
 
-
+/**
+ * Exports representation of the current sketch in Ketcher, in the specified format.
+ * @param format
+ * @returns {Promise<string>}
+ */
 function getRepresentationInFormat(format) {
-	const input_mol = molfile.stringify(ketcher.editor.struct(),
-		{ ignoreErrors: true });
+	const input_mol = molfile.stringify(ketcher.editor.struct(), {
+		ignoreErrors: true
+	});
+	// TODO: Remove Plexus usage for converting between formats
 	return new Promise((resolve) => {
 		$.ajax({
 			type: "POST",
 			url: '/plexus/rest-v0/util/calculate/stringMolExport',
 			data: { structure: input_mol, parameters: format }
-		}).done(function updateInputCompound(smiles) {
-			resolve(smiles);
+		}).done(function updateInputCompound(representation) {
+			resolve(representation);
+		}).fail(function onError() {
+			throw new Error('Could not perform the conversion');
 		});
 	});
 }
 
 function getSvg() {
-	const mol = Module.get_mol(molfile.stringify(ketcher.editor.struct(), // eslint-disable-line no-undef
-		{ ignoreErrors: true }));
+	const mol = Module.get_mol(molfile.stringify(ketcher.editor.struct(), {
+		ignoreErrors: true
+	}));
 	return mol.get_svg();
 }
 
 function setMolecule(molString) {
-	if (!(typeof molString === 'string'))
+	if (!(typeof molString === 'string')) {
 		return;
+	}
 	$.ajax({
 		type: "POST",
 		url: '/plexus/rest-v0/util/calculate/stringMolExport',

--- a/src/template/index.hbs
+++ b/src/template/index.hbs
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="{{pkg.name}}.css">
 		<script src="raphael.min.js"></script>
 		<script src="{{pkg.name}}.js"></script>
+		<script type="text/javascript" src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
 
     {{#if miew}}
         <link rel="stylesheet" href="Miew.min.css">


### PR DESCRIPTION
Ketcher side changes for https://crucible.bb.schrodinger.com/cru/SB-18052

1. Added a new API - getRepresentationInFormat, which exports the currently sketched representation in Ketcher, in the specified MoleculeFormat. (this currently uses the Plexus convert service)
2. Modified the existing setMolecule API, to import a given representation (in any format) to Ketcher.
3. ..Also added a new API getSvg, which returns the SVG of the current sketch in Ketcher - this internally uses RDKitJs' get_svg method. 
4. Pushed the built artifacts (the `dist/` directory) to remote, so that it can be directly utilized with LiveDesign, as a github dependency in NPM.

Primary: @mycrobe 