### PR TITLE
[DESIS Internal Review] SS-29663: [MOL V3000 writer] Writes S-Groups

### DIFF
--- a/src/script/chem/molfile/molfile.js
+++ b/src/script/chem/molfile/molfile.js
@@ -308,12 +308,18 @@ Molfile.prototype.writeSGroupBlock3000 = function (molecule) {
 		var sgroup = molecule.sgroups.get(id);
 		let sgDetails = `${this.getMol3000Prefix()}${id + 1} ${sgroup.type} 0`;
 		if (sgroup.atoms.length) {
+			// atoms that define the Sgroup
+			// ATOMS=(natoms aidx1 aidx2 ..)
 			sgDetails += ` ATOMS=(${sgroup.atoms.length} ${sgroup.atoms.map(atom => atom + 1).join(' ')})`;
 		}
 		if (sgroup.bonds && sgroup.bonds.length) {
+			// crossing bonds
+			// XBONDS=(nxbonds bidx1 bidx2 ..)
 			sgDetails += ` XBONDS=(${sgroup.bonds.length} ${sgroup.bonds.map(bond => bond + 1).join(' ')})`;
 		}
 		if (sgroup.patoms) {
+			// paradigmatic repeating unit atoms
+			// PATOMS=(npatoms aidx1 aidx2 ..)
 			sgDetails += ` PATOMS=(${sgroup.patoms.length} ${sgroup.patoms.map(patom => patom + 1).join(' ')})`;
 		}
 		// TODO: Add support for following:
@@ -330,6 +336,7 @@ Molfile.prototype.writeSGroupBlock3000 = function (molecule) {
 		// 11. BRKTYP
 		if (sgroup.type === 'DAT') {
 			if (sgroup.data.fieldName.length > 0) {
+				// the name of data field for Data Sgroup.
 				sgDetails += ` FIELDNAME=${sgroup.data.fieldName}`;
 			}
 			// TODO: confirm whether FIELDINFO is just units.
@@ -340,6 +347,7 @@ Molfile.prototype.writeSGroupBlock3000 = function (molecule) {
 				// NOTE: please refer to the fixed length string in parseSGroup#applyDataSGroupInfo
 				// for writing FIELDDISP, OR refer to page 22 of the spec
 				// https://drive.google.com/file/d/0Bx3dsPc7eyZKdXlHTktQTFJUMHc/view, under 'M  SDD ..'
+				// FIELDDISP is the Data Sgroup field display information
 				const x = this.getAtomCoordinate3000(sgroup.pp.x, 4).toString().padStart(10, ' ');
 				const y = this.getAtomCoordinate3000(-sgroup.pp.y, 4).toString().padStart(10, ' ');
 				const eee = '   ';
@@ -356,22 +364,28 @@ Molfile.prototype.writeSGroupBlock3000 = function (molecule) {
 				sgDetails += ` FIELDDISP="${x}${y} ${eee}${f}${g}${h} ${i} ${jjj}${kkk} ${ll} ${m}  ${n}${oo}"`;
 			}
 			if (sgroup.data.query.length > 0) {
+				// querytype is the type of query or no query if missing.
 				sgDetails += ` QUERYTYPE=${sgroup.data.query}`;
 			}
 			if (sgroup.data.queryOp.length > 0) {
+				// queryop is the query operator
 				sgDetails += ` QUERYOP=${sgroup.data.queryOp}`;
 			}
 			if (sgroup.data.fieldValue.length > 0) {
+				// fielddata is the query or field data.
 				sgDetails += ` FIELDDATA=${sgroup.data.fieldValue}`;
 			}
 		}
+		// CON
 		sgDetails += ` CONNECT=${sgroup.data.connectivity.toUpperCase()}`;
 		var parentId = this.molecule.sGroupForest.parent.get(id) + 1;
 		if (parentId > 0) {
+			// parent Sgroup index.
 			sgDetails += ` PARENT=${parentId}`;
 		}
 		const brackedCoords = sgroup.bracketBox;
 		if (brackedCoords) {
+			// display coordinates in each bracket.
 			const bracket1X = this.getAtomCoordinate3000(brackedCoords.p0.x, 4);
 			const bracket1Y = this.getAtomCoordinate3000(brackedCoords.p0.y, 4);
 			const bracket1Z = 0;
@@ -380,6 +394,7 @@ Molfile.prototype.writeSGroupBlock3000 = function (molecule) {
 			const bracket2Z = 0;
 			sgDetails += ` BRKXYZ=(9 ${bracket1X} ${bracket1Y} ${bracket1Z} ${bracket2X} ${bracket2Y} ${bracket2Z} 0 0 0)`;
 		}
+		// display label for this Sgroup.
 		sgDetails += ` LABEL=${sgroup.data.subscript}`;
 		const sgDetailsLines = sgDetails.match(/.{1,70}/g);
 		this.writeCR(sgDetailsLines.join('-\nM  V30 '));

--- a/src/script/chem/molfile/molfile.js
+++ b/src/script/chem/molfile/molfile.js
@@ -325,6 +325,9 @@ Molfile.prototype.writeSGroupBlock3000 = function (molecule) {
 		// 6. XBCORR
 		// 7. ESTATE
 		// 8. CSTATE
+		// 9. CLASS
+		// 10. SAP
+		// 11. BRKTYP
 		if (sgroup.type === 'DAT') {
 			if (sgroup.data.fieldName.length > 0) {
 				sgDetails += ` FIELDNAME=${sgroup.data.fieldName}`;

--- a/src/script/chem/molfile/molfile.js
+++ b/src/script/chem/molfile/molfile.js
@@ -344,10 +344,24 @@ Molfile.prototype.writeSGroupBlock3000 = function (molecule) {
 				sgDetails += ` FIELDINFO=${sgroup.data.units}`;
 			}
 			if (sgroup.pp) {
-				// NOTE: please refer to the fixed length string in parseSGroup#applyDataSGroupInfo
-				// for writing FIELDDISP, OR refer to page 22 of the spec
-				// https://drive.google.com/file/d/0Bx3dsPc7eyZKdXlHTktQTFJUMHc/view, under 'M  SDD ..'
-				// FIELDDISP is the Data Sgroup field display information
+				// NOTE: please refer to https://drive.google.com/file/d/0Bx3dsPc7eyZKdXlHTktQTFJUMHc/view
+				//
+				// *Data Sgroup Display Information [Sgroup]*
+				// M SDD sss xxxxx.xxxxyyyyy.yyyy eeefgh i jjjkkk ll m noo
+				//
+				// sss: Index of data Sgroup
+				// x,y: Coordinates (2F10.4)
+				// eee: (Reserved for future use)
+				// f: Data display, A = attached, D = detached
+				// g: Absolute, relative placement, A = absolute, R = relative
+				// h: Display units, blank = no units displayed, U = display units
+				// i: (Reserved for future use)
+				// jjj: Number of characters to display (1...999 or ALL)
+				// kkk: Number of lines to display (unused, always 1)
+				// ll: (Reserved for future use)
+				// m: Tag character for tagged detached display (if non-blank)
+				// n: Data display DASP position (1...9). (MACCS-II only)
+				// oo: (Reserved for future use)
 				const x = this.getAtomCoordinate3000(sgroup.pp.x, 4).toString().padStart(10, ' ');
 				const y = this.getAtomCoordinate3000(-sgroup.pp.y, 4).toString().padStart(10, ' ');
 				const eee = '   ';
@@ -376,7 +390,6 @@ Molfile.prototype.writeSGroupBlock3000 = function (molecule) {
 				sgDetails += ` FIELDDATA=${sgroup.data.fieldValue}`;
 			}
 		}
-		// CON
 		sgDetails += ` CONNECT=${sgroup.data.connectivity.toUpperCase()}`;
 		var parentId = this.molecule.sGroupForest.parent.get(id) + 1;
 		if (parentId > 0) {

--- a/src/script/chem/molfile/v3000.js
+++ b/src/script/chem/molfile/v3000.js
@@ -162,6 +162,8 @@ function v3000parseSGroup(ctab, ctabLines, sgroups, atomMap, shift) { // eslint-
 			sg.data.connectivity = props['CONNECT'][0].toLowerCase();
 		if (props['FIELDDISP'])
 			sGroup.applyDataSGroupInfo(sg, stripQuotes(props['FIELDDISP'][0]));
+		if (props['FIELDINFO'])
+			sg.data.units = props['FIELDINFO'][0];
 		if (props['FIELDDATA'])
 			sGroup.applyDataSGroupData(sg, props['FIELDDATA'][0], true);
 		if (props['FIELDNAME'])

--- a/src/script/chem/struct/sgroup.js
+++ b/src/script/chem/struct/sgroup.js
@@ -37,8 +37,8 @@ function SGroup(type) { // eslint-disable-line max-statements
 	this.selectionPlate = null;
 
 	this.atoms = [];
-	this.patoms = [];
-	this.bonds = [];
+	this.patoms = []; // paradigmatic repeating unit atoms
+	this.bonds = []; // for some reason this corresponds to xbonds as mentioned in the spec https://drive.google.com/file/d/0Bx3dsPc7eyZKdXlHTktQTFJUMHc/view
 	this.xBonds = [];
 	this.neiAtoms = [];
 	this.pp = null;
@@ -46,13 +46,13 @@ function SGroup(type) { // eslint-disable-line max-statements
 		mul: 1, // multiplication count for MUL group
 		connectivity: 'ht', // head-to-head, head-to-tail or either-unknown
 		name: '',
-		subscript: 'n',
+		subscript: 'n', // we use this as the display label for the s-group
 
 		// data s-group fields
 		attached: false,
 		absolute: true,
 		showUnits: false,
-		nCharsToDisplay: -1,
+		nCharsToDisplay: -1, // -1 corresponds to "ALL"
 		tagChar: '',
 		daspPos: 1,
 		fieldType: 'F',


### PR DESCRIPTION
- Adds MOL V3000 writer to Ketcher, which constructs the MOL V3000 representation from the underlying [`struct`](https://github.com/schrodinger/ketcher-schrodinger/blob/master/src/script/chem/struct/index.js) data structure.
- This PR addresses writing S-Groups in V3000 format, as described in the [CTFile Representation Documentation, Chapter 10: The Extended Connection Table (V3000)](https://drive.google.com/file/d/0Bx3dsPc7eyZKdXlHTktQTFJUMHc/view)
- Tested with data S-Groups and repeating chains etc. 
- Please note that the S-Group action in Ketcher (i.e., creating S-Groups by using the tool icon) is currently faulty (https://jira.schrodinger.com/browse/SS-29662). However, the V3000 reading (parsing) logic is correct. So, for testing, 
1. sketch S-Groups in an external sketcher (say Marvin), and export the V3000 representation
2. import this representation to Ketcher,
3. now export the representation from Ketcher in V3000 format
4. import this representation back to the external sketcher to verify the structure is exactly the same

Primary - @somavara 