### PR TITLE
SS-28762: Create Infrastructure for supporting different toolbar type modes in Ketcher

### DIFF
--- a/src/script/index.js
+++ b/src/script/index.js
@@ -109,6 +109,11 @@ function showMolfile(clientArea, molString, options) {
 	return render;
 }
 
+
+function setToolbarType(toolbarType) {
+	ketcher.ui.changeToolbarType(toolbarType);
+}
+
 // TODO: replace window.onload with something like <https://github.com/ded/domready>
 // to start early
 window.onload = function () {
@@ -145,6 +150,7 @@ const ketcher = module.exports = Object.assign({ // eslint-disable-line no-multi
 	getMolfile,
 	getRepresentationInFormat,
 	setMolecule,
+	setToolbarType,
 	addFragment,
 	showMolfile
 }, buildInfo);

--- a/src/script/index.js
+++ b/src/script/index.js
@@ -21,6 +21,7 @@ import queryString from 'query-string';
 import api from './api';
 import molfile from './chem/molfile';
 import smiles from './chem/smiles';
+import toolbarTypeMap from './ui/state/toolbar/toolbartypes';
 import * as structformat from './ui/data/convert/structformat';
 
 import ui from './ui';
@@ -109,7 +110,10 @@ function showMolfile(clientArea, molString, options) {
 	return render;
 }
 
-
+/**
+ * Sets the toolbar type for Ketcher
+ * @param toolbarType {toolbarTypeMap}
+ */
 function setToolbarType(toolbarType) {
 	ketcher.ui.changeToolbarType(toolbarType);
 }

--- a/src/script/ui/action/server.js
+++ b/src/script/ui/action/server.js
@@ -23,7 +23,7 @@ export default {
 		action: {
 			thunk: serverTransform('layout')
 		},
-		disabled: (editor, server, options) => !options.app.server
+		disabled: (editor, server, options) => !options.app.server,
 	},
 	clean: {
 		shortcut: 'Mod+Shift+l',

--- a/src/script/ui/app/index.jsx
+++ b/src/script/ui/app/index.jsx
@@ -46,7 +46,7 @@ const App = connect(
 });
 
 function init(el, options, server) {
-	var store = createStore(options, server);
+	const store = createStore(options, server);
 	store.dispatch(initKeydownListener(el));
 	store.dispatch(initResize());
 

--- a/src/script/ui/app/index.jsx
+++ b/src/script/ui/app/index.jsx
@@ -25,7 +25,7 @@ import Toolbar from './toolbar';
 import createStore, { onAction, load } from '../state';
 import { checkServer } from '../state/server';
 import { initKeydownListener } from '../state/hotkeys';
-import { initResize } from '../state/toolbar';
+import { initResize, updateToolbarType } from '../state/toolbar';
 
 const App = connect(
 	null,
@@ -46,7 +46,7 @@ const App = connect(
 });
 
 function init(el, options, server) {
-	const store = createStore(options, server);
+	var store = createStore(options, server);
 	store.dispatch(initKeydownListener(el));
 	store.dispatch(initResize());
 
@@ -57,7 +57,8 @@ function init(el, options, server) {
 	), el);
 
 	return {
-		load: (structStr, opts) => store.dispatch(load(structStr, opts))
+		load: (structStr, opts) => store.dispatch(load(structStr, opts)),
+		changeToolbarType: toolbarType => store.dispatch(updateToolbarType(toolbarType))
 	};
 }
 

--- a/src/script/ui/app/toolbar.jsx
+++ b/src/script/ui/app/toolbar.jsx
@@ -267,7 +267,8 @@ export default connect(
 		status: state.actionState || {},
 		freqAtoms: state.toolbar.freqAtoms,
 		opened: state.toolbar.opened,
-		visibleTools: state.toolbar.visibleTools
+		visibleTools: state.toolbar.visibleTools,
+		toolbarType: state.toolbar.toolbarType
 	}),	{
 		onOpen: (menuName, isSelected) => ({ type: 'OPENED', data: { menuName, isSelected } })
 	}

--- a/src/script/ui/component/actionmenu.jsx
+++ b/src/script/ui/component/actionmenu.jsx
@@ -21,6 +21,7 @@ import classNames from 'classnames';
 import action from '../action';
 import { hiddenAncestor } from '../state/toolbar';
 import Icon from './view/icon';
+import toolbarTypeMap from '../state/toolbar/toolbartypes';
 
 const isMac = /Mac/.test(navigator.platform); // eslint-disable-line no-undef
 const shortcutAliasMap = {
@@ -62,8 +63,11 @@ export function showMenuOrButton(action, item, status, props) { // eslint-disabl
 	return (item.component(props));
 }
 
-function ActionButton({ name, action, status = {}, onAction }) { // eslint-disable-line no-shadow
+function ActionButton({ name, action, status = {}, onAction, toolbarType}) { // eslint-disable-line no-shadow
 	const shortcut = action.shortcut && shortcutStr(action.shortcut);
+	if (toolbarTypeMap[toolbarType].includes(action.title)) {
+		return;
+	}
 	return (
 		<button
 			disabled={status.disabled}

--- a/src/script/ui/state/toolbar/index.js
+++ b/src/script/ui/state/toolbar/index.js
@@ -24,7 +24,8 @@ const initial = {
 	opened: null,
 	visibleTools: {
 		select: 'select-lasso'
-	}
+	},
+	toolbarType: 'ABC'
 };
 const MAX_ATOMS = 7;
 
@@ -61,6 +62,12 @@ export function initIcons(cacheEl) {
 	});
 }
 
+export function updateToolbarType(toolbarType) {
+	return (dispatch) => {
+		dispatch({ type: 'UPDATE_TOOLBAR_TYPE', data: toolbarType });
+	};
+}
+
 /* REDUCER */
 export default function (state = initial, action) {
 	const { type, data } = action;
@@ -90,6 +97,8 @@ export default function (state = initial, action) {
 		return { ...state, opened: null };
 	case 'MODAL_OPEN':
 		return { ...state, opened: null };
+	case 'UPDATE_TOOLBAR_TYPE':
+		return { ...state, toolbarType: data };
 	default:
 		return state;
 	}

--- a/src/script/ui/state/toolbar/toolbartypes.js
+++ b/src/script/ui/state/toolbar/toolbartypes.js
@@ -1,13 +1,8 @@
 // Stoes the map of toolbar type enum --> <List of tool icons to hide>
-// Note that
+// Note that by default, all icons will be showed
 
 const toolbarTypeMap = {
-	ABC: [
-		'Layout',
-		'Clean Up',
-		'Aromatize',
-		'Chain'
-	],
+	ABC: [],
 	DEF: [
 		'Clean Up',
 		'Chain'

--- a/src/script/ui/state/toolbar/toolbartypes.js
+++ b/src/script/ui/state/toolbar/toolbartypes.js
@@ -1,0 +1,17 @@
+// Stoes the map of toolbar type enum --> <List of tool icons to hide>
+// Note that
+
+const toolbarTypeMap = {
+	ABC: [
+		'Layout',
+		'Clean Up',
+		'Aromatize',
+		'Chain'
+	],
+	DEF: [
+		'Clean Up',
+		'Chain'
+	]
+};
+
+export default toolbarTypeMap;


### PR DESCRIPTION
This PR adds a new plug-n-play architecture for supporting multiple toolbar type modes in Ketcher, similar to what we currently have in Marvin. This enables us to show only the relevant tools for each user functionality.

As the list of toolbar enums (with the list of functionalities) has not been finalized by product yet, I have exposed dummy toolbar enums ('ABC' and 'DEF' for now)

This modification of toolbar mode can be done via the Ketcher JS API exposed in this PR - `ketcher.setToolbarType`

Tested it out by triggering this JS API call (through debugger tools) with 'ABC' and 'DEF'.

A [follow-up ticket](https://jira.schrodinger.com/browse/SS-29813) would address replacing the dummy toolbar type enums with actual names.

Primary - @mycrobe 