### PR TITLE
SS-29644: MOL V3000: Add parsing for Collection Block (Enhanced Stereo Labels)

### DIFF
--- a/src/script/chem/molfile/v3000.js
+++ b/src/script/chem/molfile/v3000.js
@@ -119,14 +119,14 @@ function v3000parseCollection(ctab, ctabLines, shift) {
 			throw new Error('A record of form AAA=BBB or AAA=(...) expected, got \'' + split[i] + '\'');
 		const name = subsplit[0];
 		const prop = { [name]: subsplit[1] };
-		if (line.includes("STEABS")) {
+		if (line.includes('STEABS')) {
 			ctab.enhancedStereo.abs = parseBracedNumberList(prop['ATOMS'], -1);
-		} else if (line.includes("STERAC")) {
+		} else if (line.includes('STERAC')) {
 			const n = line.substring(line.indexOf('STERAC') + 6, line.indexOf('ATOMS')).trim();
-			ctab.enhancedStereo.rac[parseInt(n, 10)] = parseBracedNumberList(prop['ATOMS'], -1);
-		} else if (line.includes("STEREL")) {
+			ctab.enhancedStereo.rac.set(parseInt(n, 10), parseBracedNumberList(prop['ATOMS'], -1));
+		} else if (line.includes('STEREL')) {
 			const n = line.substring(line.indexOf('STEREL') + 6, line.indexOf('ATOMS')).trim();
-			ctab.enhancedStereo.rel[parseInt(n, 10)] = parseBracedNumberList(prop['ATOMS'], -1);
+			ctab.enhancedStereo.rel.set(parseInt(n, 10), parseBracedNumberList(prop['ATOMS'], -1));
 		}
 		shift++;
 	}

--- a/src/script/chem/molfile/v3000.js
+++ b/src/script/chem/molfile/v3000.js
@@ -111,8 +111,25 @@ function parseBondLineV3000(line) {
 function v3000parseCollection(ctab, ctabLines, shift) {
 	/* reader */
 	shift++;
-	while (ctabLines[shift].trim() != 'M  V30 END COLLECTION')
+	while (ctabLines[shift].trim() != 'M  V30 END COLLECTION') {
+		const line = ctabLines[shift];
+		const atoms = line.substr(line.indexOf("ATOMS"), line.length);
+		const subsplit = splitonce(atoms, '=');
+		if (subsplit.length != 2)
+			throw new Error('A record of form AAA=BBB or AAA=(...) expected, got \'' + split[i] + '\'');
+		const name = subsplit[0];
+		const prop = { [name]: subsplit[1] };
+		if (line.includes("STEABS")) {
+			ctab.enhancedStereo.abs = parseBracedNumberList(prop['ATOMS'], -1);
+		} else if (line.includes("STERAC")) {
+			const n = line.substring(line.indexOf('STERAC') + 6, line.indexOf('ATOMS')).trim();
+			ctab.enhancedStereo.rac[parseInt(n, 10)] = parseBracedNumberList(prop['ATOMS'], -1);
+		} else if (line.includes("STEREL")) {
+			const n = line.substring(line.indexOf('STEREL') + 6, line.indexOf('ATOMS')).trim();
+			ctab.enhancedStereo.rel[parseInt(n, 10)] = parseBracedNumberList(prop['ATOMS'], -1);
+		}
 		shift++;
+	}
 	shift++;
 	return shift;
 }

--- a/src/script/chem/struct/enhancedstereo.js
+++ b/src/script/chem/struct/enhancedstereo.js
@@ -17,9 +17,9 @@
 import Pool from '../../util/pool';
 
 function EnhancedStereo(molecule) {
-	this.abs = [];
-	this.rac = new Pool(); // n -> list of atom ids
-	this.rel = new Pool(); // n -> list of atom ids
+	this.abs = []; // absolute stereo info
+	this.rac = new Pool(); // n -> list of atom ids // racemic stereo info
+	this.rel = new Pool(); // n -> list of atom ids // relative stereo info
 	this.molecule = molecule;
 }
 export default EnhancedStereo;

--- a/src/script/chem/struct/enhancedstereo.js
+++ b/src/script/chem/struct/enhancedstereo.js
@@ -1,0 +1,25 @@
+/****************************************************************************
+ * Copyright 2018 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***************************************************************************/
+
+import Pool from '../../util/pool';
+
+function EnhancedStereo(molecule) {
+	this.abs = [];
+	this.rac = new Pool(); // n -> list of atom ids
+	this.rel = new Pool(); // n -> list of atom ids
+	this.molecule = molecule;
+}
+export default EnhancedStereo;

--- a/src/script/chem/struct/index.js
+++ b/src/script/chem/struct/index.js
@@ -27,10 +27,12 @@ import Bond from './bond';
 import SGroup from './sgroup';
 import RGroup from './rgroup';
 import SGroupForest from './sgforest';
+import EnhancedStereo from './enhancedstereo';
 
 function Struct() {
 	this.atoms = new Pool();
 	this.bonds = new Pool();
+	this.enhancedStereo = new EnhancedStereo(this);
 	this.sgroups = new Pool();
 	this.halfBonds = new Pool();
 	this.loops = new Pool();

--- a/src/script/index.js
+++ b/src/script/index.js
@@ -79,9 +79,13 @@ function setMolecule(molString) {
 	$.ajax({
 		type: "POST",
 		url: '/plexus/rest-v0/util/calculate/stringMolExport',
-		data: { structure: molString, parameters: 'MOL' }
-	}).done(function updateInputCompound(smiles) {
-		ketcher.ui.load(smiles, {
+		data: { structure: molString, parameters: 'mol:V3' }
+	}).done(function updateInputCompound(molfile) {
+		ketcher.ui.load(molfile, {
+			rescale: true
+		});
+	}).fail(function onError() {
+		ketcher.ui.load(molString, {
 			rescale: true
 		});
 	});


### PR DESCRIPTION
Introduced new fields inside the Ketcher internal molecule data structure to store specific information wrt enhanced stereo labels, as mentioned on page 92 of the [spec](https://drive.google.com/file/d/0Bx3dsPc7eyZKdXlHTktQTFJUMHc/view)

Primary - @mycrobe 