### PR TITLE
SS-29875: Ketcher: MOL V3000 writer clean-up & refactors

### DIFF
--- a/src/script/chem/molfile/v3000.js
+++ b/src/script/chem/molfile/v3000.js
@@ -137,7 +137,7 @@ function v3000parseSGroup(ctab, ctabLines, sgroups, atomMap, shift) { // eslint-
 		var props = {};
 		for (var i = 3; i < split.length; ++i) {
 			var subsplit = splitonce(split[i], '=');
-			if (subsplit.length != 2)
+			if (subsplit.length !== 2 || subsplit[0].length === 0 || subsplit[1].length === 0)
 				throw new Error('A record of form AAA=BBB or AAA=(...) expected, got \'' + split[i] + '\'');
 			var name = subsplit[0];
 			if (!(name in props))


### PR DESCRIPTION
As part of this PR, extracted some of the existing code to utils, for example -
1. the text-wrapping logic
2. conversion b/w 0-based and 1-based indexing for Ketcher & outside world
Also improved an error checking condition as mentioned in https://github.com/schrodinger/ketcher/pull/12/files#r391028378.

Primary - @mycrobe 