### PR TITLE
SS-29674: [MOL V3000 writer] Writes isotopes

### DIFF
--- a/src/script/chem/molfile/molfile.js
+++ b/src/script/chem/molfile/molfile.js
@@ -541,9 +541,11 @@ Molfile.prototype.writeAtomBlock3000 = function (molecule) {
 		if (atom.rglabel != null && atom.label === 'R#') {
 			atomDetails += ` RGROUPS=(1 ${atom.rglabel})`;
 		}
+		if (atom.isotope !== 0) {
+			atomDetails += ` MASS=${atom.isotope}`;
+		}
 		// TODO: Add support for following:
 		// 1. CFG - Stereo configuration
-		// 2. MASS - Atomic weight
 		// 3. STBOX - Stereo box
 		// 4. ATTCHORD - Attachment order
 

--- a/src/script/index.js
+++ b/src/script/index.js
@@ -83,9 +83,13 @@ function setMolecule(molString) {
 	$.ajax({
 		type: "POST",
 		url: '/plexus/rest-v0/util/calculate/stringMolExport',
-		data: { structure: molString, parameters: 'MOL' }
-	}).done(function updateInputCompound(smiles) {
-		ketcher.ui.load(smiles, {
+		data: { structure: molString, parameters: 'MOL:V3' }
+	}).done(function updateInputCompound(molfile) {
+		ketcher.ui.load(molfile, {
+			rescale: true
+		});
+	}).fail(function onError() {
+		ketcher.ui.load(molString, {
 			rescale: true
 		});
 	});


### PR DESCRIPTION
Apparently there was already a field in the ketcher Atom object named `isotope`, which stores its atomic mass. This is set to 0, if its a regular atom, and is set to the exact atomic mass, in case of an isotope.

Primary - @mycrobe 